### PR TITLE
Copyto matlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,18 @@ This library provides a variety of features for integrating ImageJ with MATLAB, 
 * IJM commands - When ImageJ is started within MATLAB, utility methods for converting between ImageJ and MATLAB data structures will be available. Run `IJM.help` for a list of commands.
 * MATLAB dataset conversion - ImageJ Datasets can now be converted, using the `ConvertService`, to the Matlab Control MatlabNumericArray types. These arrays can then be passed to a running MATLAB instance as a matrix.
 * MATLAB array preprocessor - MATLAB scripts (.m) can now have `@matrix` annotations. This will automatically take the active ImageJ Dataset and convert it to a matrix in MATLAB.
+
+
+
+## Documentation
+
+Detailed instruction of how to use ImageJ-MATLAB is here:
+
+https://imagej.net/MATLAB_Scripting
+
+
+
+## Publication
+
+Hiner MC, Rueden CT, Eliceiri KW (2017) ImageJ-MATLAB: a bidirectional framework for scientific image analysis interoperability. *Bioinformatics* **33**:629–630, https://doi.org/[10.1093/bioinformatics/btw681](https://doi.org/10.1093/bioinformatics/btw681)
+

--- a/src/main/resources/script_templates/MATLAB/copytoMatlab.m
+++ b/src/main/resources/script_templates/MATLAB/copytoMatlab.m
@@ -1,20 +1,53 @@
 function I = copytoMatlab(img)
-%%COPYTOMATLAB Copy the content of an ImgLib2 image to MATLAB.
+%copytoMatlab copies the content of an ImgLib2 Image (ImageJ2) or ImagePlus
+% (ImageJ1) to MATLAB.
+%
+% SYNTAX
+% I = copytoMatlab(img)
+% I = copytoMatlab(imp)
 %
 % I = copytoMatlab(img) returns a MATLAB copy of the array stored in the
 % specified ImgLib2 Img object. This function only works for ImgLib2 images
-% that are ArrayImgs, and whose types are native real or integer ones. 
-% 
+% that are ArrayImgs, and whose types are native real or integer ones.
+%
+% I = copytoMatlab(imp) returns a MATLAB copy of the array stored in the
+% specified ij.ImagePlus object (ImageJ1).
+%
+% INPUT ARGUMENTS
+% img         a net.imglib2.img.array.ArrayImg object (ImgLib2/ImageJ2)
+%
+% imp         a ij.ImagePlus object (ImageJ1)
+%
+%
+% OUTPUT ARGUMENTS
+% I           array of image data.
+%
+% NOTE
+%
 % We rely on Miji to set up classpath, so you would have to add Miji to
 % your MATLAB path and call
 %  >> Miji(false); % or true
 % prior to using this function.
 %
-% see also: copytoImgPlus, copytoImg
+%
+% Image:
 % Jean-Yves Tinevez - 2013
+%
+% ImagePlus:
+% Written by Kouichi C. Nakamura Ph.D.
+% MRC Brain Network Dynamics Unit
+% University of Oxford
+% kouichi.c.nakamura@gmail.com
+% 29-Sep-2018 10:20:48
+%
+% see also
+% copytoImgPlus, copytoImg, copytoImagePlus
 
+
+if isa(img,'net.imglib2.img.array.ArrayImg')
+    
     %% CONSTANTS
-
+    
     ACCEPTED_TYPES = {
         'net.imglib2.type.numeric.integer.UnsignedByteType'
         'net.imglib2.type.numeric.integer.UnsignedShortType'
@@ -29,7 +62,7 @@ function I = copytoMatlab(img)
         };
     
     %% Check input
-
+    
     if ~isa(img, 'net.imglib2.img.array.ArrayImg')
         error('MATLAB:copytoMatlab:IllegalArgument', ...
             'Expected argument to be an ImgLib2 ArrayImg, got a %s.', ...
@@ -39,10 +72,10 @@ function I = copytoMatlab(img)
     fel = img.firstElement;
     knowType = false;
     for i = 1 : numel(ACCEPTED_TYPES)
-       if isa(fel, ACCEPTED_TYPES{i})
-           knowType = true;
-           break
-       end
+        if isa(fel, ACCEPTED_TYPES{i})
+            knowType = true;
+            break
+        end
     end
     
     if ~knowType
@@ -50,8 +83,7 @@ function I = copytoMatlab(img)
             'Can only deal with native real or integer types, got a %s.', ...
             class(fel) )
     end
-    
-    
+
     
     %% Operate on source image
     
@@ -73,9 +105,150 @@ function I = copytoMatlab(img)
     elseif isa(fel, 'net.imglib2.type.numeric.integer.UnsignedIntType')
         J = typecast(J, 'uint32');
     end
-
+    
     % Build MATLAB array
     I = reshape(J, sizes);
     I = permute(I, [2 1]);
+    
+elseif isa(img,'ij.ImagePlus')
+    
+    imp = img;
+    clear img;
+    
+    dim = double(imp.getDimensions);
+    
+    switch imp.getBitDepth
+        case 8
+            I = zeros(dim(2),dim(1),dim(3),dim(4),dim(5),'uint8');
+            
+        case 16
+            I = zeros(dim(2),dim(1),dim(3),dim(4),dim(5),'uint16');
+            
+        case 24 %RGB
+            I = zeros(dim(2),dim(1),dim(3),'uint8');
+            
+            channels = ij.plugin.ChannelSplitter.split(imp);
+            
+            for c = 1:3
+                for z = 1:dim(4)
+                    channels(c).setZ(z);
+                    for t = 1:dim(5)
+                        channels(c).setT(t);
+                        I(:,:,c,z,t) = local_getPixels(channels(c),dim);
+                    end
+                end
+            end
+            
+            return
+        case 32
+            error('not supported yet')
+        case 64
+            error('not supported yet')
+        otherwise
+            error('not supported yet')
+    end
+    
+    
+    if nnz(dim(3:5) == 1) == 2
+        
+        DIM = dim(find(dim(3:5) ~= 1)+2);
+        for i = 1:DIM
+            imp.setSlice(i);
+            
+            switch find(dim(3:5) ~= 1)
+                case 1
+                    c = i;
+                    z = 1;
+                    t = 1;
+                case 2
+                    c = 1;
+                    z = i;
+                    t = 1;
+                case 3
+                    c = 1;
+                    z = 1;
+                    t = i;
+            end
+            
+            P = local_getPixels(imp,dim);
+            
+            I(:,:,c,z,t) = P;
+            
+        end
+        
+        
+    elseif imp.isHyperStack
+        
+        for c = 1:dim(3) %TODO parfor? I cannot be used as is
+            imp.setC(c);
+            
+            for z = 1:dim(4)
+                imp.setZ(z);
+                for t = 1:dim(5)
+                    imp.setT(t);
+                    
+                    P = local_getPixels(imp,dim);
+                    
+                    I(:,:,c,z,t) = P;
+                    
+                end
+            end
+        end
+        
+    elseif imp.isComposite
+        
+        
+        for c= 1:dim(3)
+            imp.setSlice(c); % MUCH faster than setC(c) for big images
+            
+            for z = 1:dim(4)
+                imp.setZ(z);
+                for t = 1:dim(5)
+                    imp.setZ(t);
+                    
+                    P = local_getPixels(imp,dim);
+                    
+                    I(:,:,c,z,t) = P;
+                end
+            end
+        end
+        
+    else
+        
+        P = local_getPixels(imp,dim);
+        
+        I = P;
+        
+    end
 
 end
+
+end
+
+%--------------------------------------------------------------------------
+
+function P = local_getPixels(imp,dim)
+
+ip = imp.getChannelProcessor;
+
+% f = ip.getFloatArray; % single, SLOW
+% c = ip.getIntArray; % int32, SLOW
+
+p = ip.getPixels; % vector, int16, very quick
+
+switch class(p)
+    case 'int32' %RGB or 32-bit
+        
+    case 'int16'
+        ptc = typecast(p,'uint16'); %NOTE need to convert to uint16 from int16
+    case 'int8'
+        ptc = typecast(p,'uint8'); %NOTE need to convert to uint16 from int16
+        
+end
+
+P = reshape(ptc,dim(1),dim(2))';
+
+end
+
+
+

--- a/src/main/resources/script_templates/MATLAB/copytoMatlab_test.m
+++ b/src/main/resources/script_templates/MATLAB/copytoMatlab_test.m
@@ -1,0 +1,68 @@
+classdef copytoMatlab_test < matlab.unittest.TestCase
+    %copytoMatlab_test is a unit test for coptyMatlab
+    %
+    % Written by Kouichi C. Nakamura Ph.D.
+    % MRC Brain Network Dynamics Unit
+    % University of Oxford
+    % kouichi.c.nakamura@gmail.com
+    % 11-Oct-2018 23:33:27
+    %
+    % See also
+    % coptyMatlab
+
+
+    
+    properties
+        FijiAppspath
+    end
+    
+    methods
+        function obj = copytoMatlab_test(fijiapppath)
+            
+            
+       
+        end
+    end
+    
+    methods (Test)
+        function test1(testCase)
+            
+            addpath(fullfile(testCase.FijiAppspath,'scripts')) %TODO avoid using getfijipath
+            ImageJ
+            
+            eval('import ij.IJ')
+            
+            %%
+            A = randi(255,200,300,'uint8');
+            
+            img = copytoImg(A);
+            
+            testCase.verifyTrue(isa(img,'net.imglib2.img.array.ArrayImg'))
+            
+            testCase.verifyEqual(img.numDimensions,2)
+            testCase.verifyEqual(img.dimension(0),300)
+            testCase.verifyEqual(img.dimension(1),200)
+
+            
+            
+            
+            
+        end
+        
+        function test2(testCase)
+            %METHOD1 Summary of this method goes here
+            %   Detailed explanation goes here
+            
+            
+             %%
+            A = randi(255,200,300,'uint8');
+            
+            imp = copytoImagePlus(A);
+            
+            testCase.verifyTrue(isa(imp,'ij.ImagePlus'))
+            testCase.verifyEqual(imp.getDimensions,[300 200 1 1 1])
+
+        end
+    end
+end
+

--- a/src/scripts/update/ImageJ.m
+++ b/src/scripts/update/ImageJ.m
@@ -42,6 +42,8 @@ import net.imagej.matlab.*;
 if open_imagej
     ImageJMATLAB.start(verbose);
 else
+    ij.ImageJ([],ij.ImageJ.NO_SHOW); % same as Miji(false) .... but this prevents later use of ImageJ.m
+    
     % initialize ImageJ with the headless flag
     % ImageJMATLAB.start(verbose, '--headless'); % this does not work
     

--- a/src/scripts/update/ImageJ.m
+++ b/src/scripts/update/ImageJ.m
@@ -44,6 +44,8 @@ if open_imagej
 else
     ij.ImageJ([],ij.ImageJ.NO_SHOW); % same as Miji(false) .... but this prevents later use of ImageJ.m
     
+    warning('ImageJ is running in headless mode. Use ''ij.IJ.run("Quit","")'' to quit the instance.')
+    
     % initialize ImageJ with the headless flag
     % ImageJMATLAB.start(verbose, '--headless'); % this does not work
     


### PR DESCRIPTION
1. `src\main\resources\script_templates\MATLAB\copytoMatlab.m` now supports ImagePlus (ImageJ1) object as an input argument as well.

2. `src\main\resources\script_templates\MATLAB\copytoMatlab_test.m` is added to test the behaviors of `copytoMatlab.m`

3. `ImageJ(false)` now calls `ij.ImageJ([],ij.ImageJ.NO_SHOW)`  for headless mode.
This is similar to the way `Miji(false)` works.
